### PR TITLE
Added version to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
             "role": "Developer"
         }
     ],
+    "version": "1.3.4",
     "autoload": {
         "psr-0": {
             "Net": "./"


### PR DESCRIPTION
The composer.json doesn't have the package's version number, and was being rejected by composer require. Adding the 1.3.4 (Taken from pear) should fix this issue.