### PR TITLE
Fix autoloading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 install:
+  - composer update --no-interaction --prefer-dist
   - pear install package.xml
 php:
   - 7.4
@@ -14,4 +15,4 @@ matrix:
       dist: trusty
     - php: 5.4
       dist: trusty
-script: phpunit tests/
+script: vendor/bin/phpunit --coverage-text tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,16 @@ language: php
 install:
   - pear install package.xml
 php:
-  - 5.4
+  - 7.4
+  - 7.3
+  - 7.2
+  - 7.1
+  - 7.0
+  - 5.6
+matrix:
+  include:
+    - php: 5.5
+      dist: trusty
+    - php: 5.4
+      dist: trusty
 script: phpunit tests/

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,8 @@
     "autoload": {
         "psr-0": {
             "Net": "./"
-        }
-    },
-    "autoload-dev": {
-        "classmap": ["tests/"]
+        },
+        "exclude-from-classmap": ["tests/"]
     },
     "description": "More info available on: http://pear.php.net/package/Net_IPv4",
     "include-path": [

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
             "Net": "./"
         }
     },
+    "autoload-dev": {
+        "classmap": ["tests/"]
+    },
     "description": "More info available on: http://pear.php.net/package/Net_IPv4",
     "include-path": [
         "./"

--- a/tests/AllTests.php
+++ b/tests/AllTests.php
@@ -3,18 +3,16 @@ if (!defined('PHPUNIT_MAIN_METHOD')) {
     define('PHPUNIT_MAIN_METHOD', 'Net_IPv4_AllTests::main');
 }
 
-require_once 'PHPUnit/TextUI/TestRunner.php';
-
 require_once 'IPv4Test.php';
 
 class Net_IPv4_AllTests {
 
     public static function main() {
-        PHPUnit_TextUI_TestRunner::run(self::suite());
+        PHPUnit\TextUI\TestRunner::run(self::suite());
     }
 
     public static function suite() {
-        $suite = new PHPUnit_Framework_TestSuite();
+        $suite = new PHPUnit\Framework\TestSuite();
 
         $suite->addTestSuite('IPv4Test');
 

--- a/tests/IPv4Test.php
+++ b/tests/IPv4Test.php
@@ -1,9 +1,8 @@
 <?php
-require_once 'PHPUnit/Framework/TestCase.php';
 require_once 'Net/IPv4.php';
 require_once 'MyIPv4.php';
 
-class IPv4Test extends PHPUnit_Framework_TestCase {
+class IPv4Test extends PHPUnit\Framework\TestCase {
     protected $net;
     protected $quadIPs;
     protected $hexIPs;


### PR DESCRIPTION
The structure in the tests folder is not compatible with [PSR-0](https://www.php-fig.org/psr/psr-0/).

Therefore ["exclude-from-classmap"](https://getcomposer.org/doc/04-schema.md#exclude-files-from-classmaps) should be used to ensure proper autoloading with composer.

The lastest composer version (1.10) is currently triggering a deprecation message because of this misconfiguration (only if [autoloader optimization](https://getcomposer.org/doc/articles/autoloader-optimization.md#optimization-level-1-class-map-generation) is enabled):

`
Deprecation Notice: Class Net_IPv4_AllTests located in ./vendor/pear/net_ipv4/tests/AllTests.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:185
`